### PR TITLE
Complete Timetable Data

### DIFF
--- a/application/models/Timetable.php
+++ b/application/models/Timetable.php
@@ -102,15 +102,8 @@ class Slot extends CI_Model
         // Set the slot values from the XML elements provided.
         
         // Replace the value for day with the full day name.
-        switch((String) (isset($slot['day']) ? $slot['day'] : $container['which']))
-        {
-            case 'mon': $this->day = 'Monday'; break;
-            case 'tue': $this->day = 'Tuesday'; break;
-            case 'wed': $this->day = 'Wednesday'; break;
-            case 'thu': $this->day = 'Thursday'; break;
-            case 'fri': $this->day = 'Friday'; break;
-        }
-        
+        $this->day = (String) 
+                (isset($slot['day']) ? $slot['day'] : $container['which']);
         $this->period = (String) 
                 (isset($slot['period']) ? $slot['period'] : $container['which']);
         $this->course = (String) 

--- a/application/views/welcome_courses.php
+++ b/application/views/welcome_courses.php
@@ -1,6 +1,6 @@
 <h3>Timetable by Courses</h3>
 <br/>
 {courses}
-{day} {period} {course} {type} {instructor} {room}
+{course} | {day} | {period} | {type} | {room} | {instructor}
 <br/>
 {/courses}

--- a/application/views/welcome_days.php
+++ b/application/views/welcome_days.php
@@ -1,6 +1,6 @@
 <h3>Timetable by Days</h3>
 <br/>
 {days}
-{day} {period} {course} {type} {instructor} {room}
+{day} | {period} | {course} | {type} | {room} | {instructor}
 <br/>
 {/days}

--- a/application/views/welcome_periods.php
+++ b/application/views/welcome_periods.php
@@ -1,6 +1,6 @@
 <h3>Timetable by Periods</h3>
 <br/>
 {periods}
-{day} {period} {course} {type} {instructor} {room}
+{period} | {day} | {course} | {type} | {room} | {instructor}
 <br/>
 {/periods}

--- a/data/courses.xml
+++ b/data/courses.xml
@@ -1,24 +1,124 @@
 <courses>
+    <course which="ACIT4620">
+        <courseslot day="Tuesday" period="0830">
+            <type>Lab</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+        <courseslot day="Tuesday" period="0930">
+            <type>Lab</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+        <courseslot day="Tuesday" period="1530">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
+        </courseslot>
+        <courseslot day="Tuesday" period="1630">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
+        </courseslot>
+    </course>
     <course which="ACIT4650">
-        <courseslot day="mon" period="1030">
+        <courseslot day="Monday" period="1030">
             <type>Lab</type>
             <instructor>Medhat Elmasry</instructor>
             <room>SE12-306</room>
         </courseslot>
-        <courseslot day="mon" period="1130">
+        <courseslot day="Monday" period="1130">
             <type>Lab</type>
             <instructor>Medhat Elmasry</instructor>
             <room>SE12-306</room>
         </courseslot>
-        <courseslot day="mon" period="1630">
-            <type>Lec</type>
+        <courseslot day="Monday" period="1630">
+            <type>Lecture</type>
             <instructor>Medhat Elmasry</instructor>
             <room>SE6-205</room>
         </courseslot>
-        <courseslot day="tue" period="1230">
-            <type>Lec</type>
+        <courseslot day="Tuesday" period="1230">
+            <type>Lecture</type>
             <instructor>Medhat Elmasry</instructor>
             <room>SW9-206</room>
+        </courseslot>
+    </course>
+    <course which="ACIT4660">
+        <courseslot day="Friday" period="0830">
+            <type>Lecture</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SW9-206</room>
+        </courseslot>
+        <courseslot day="Friday" period="0930">
+            <type>Lecture</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SW9-206</room>
+        </courseslot>
+        <courseslot day="Friday" period="1330">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+        <courseslot day="Friday" period="1430">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+    </course>
+    <course which="ACIT4770">
+        <courseslot day="Friday" period="1030">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+        <courseslot day="Friday" period="1130">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+    </course>
+    <course which="ACIT4850">
+        <courseslot day="Wednesday" period="1230">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </courseslot>
+        <courseslot day="Wednesday" period="1330">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </courseslot>
+        <courseslot day="Thursday" period="1330">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </courseslot>
+        <courseslot day="Thursday" period="1430">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </courseslot>
+    </course>
+    <course which="ACIT4910">
+        <courseslot day="Monday" period="1530">
+            <type>Lecture</type>
+            <instructor>Richard Chau</instructor>
+            <room>SW9-206</room>
+        </courseslot>
+        <courseslot day="Thursday" period="0930">
+            <type>Lecture</type>
+            <instructor>Richard Chau</instructor>
+            <room>SW5-1840</room>
+        </courseslot>
+        <courseslot day="Thursday" period="1030">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
+        </courseslot>
+        <courseslot day="Thursday" period="1130">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
         </courseslot>
     </course>
 </courses>

--- a/data/days.xml
+++ b/data/days.xml
@@ -1,5 +1,5 @@
 <days>
-    <day which="mon">
+    <day which="Moday">
         <dayslot period="1030" course="ACIT4650">
             <type>Lab</type>
             <instructor>Medhat Elmasry</instructor>
@@ -11,14 +11,112 @@
             <room>SE12-306</room>
         </dayslot>
         <dayslot period="1530" course="ACIT4910">
-            <type>Lec</type>
+            <type>Lecture</type>
             <instructor>Richard Chau</instructor>
             <room>SW9-206</room>
         </dayslot>
         <dayslot period="1630" course="ACIT4650">
-            <type>Lec</type>
+            <type>Lecture</type>
             <instructor>Medhat Elmasry</instructor>
             <room>SE6-205</room>
+        </dayslot>
+    </day>
+    <day which="Tuesday">
+        <dayslot period="0830" course="ACIT4620">
+            <type>Lab</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="0930" course="ACIT4620">
+            <type>Lab</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1230" course="ACIT4650">
+            <type>Lecture</type>
+            <instructor>Medhat Elmasry</instructor>
+            <room>SW9-206</room>
+        </dayslot>
+        <dayslot period="1530" course="ACIT4620">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
+        </dayslot>
+        <dayslot period="1630" course="ACIT4620">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
+        </dayslot>
+    </day>
+    <day which="Wednesday">
+        <dayslot period="1230" course="ACIT4850">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </dayslot>
+        <dayslot period="1330" course="ACIT4850">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </dayslot>
+    </day>
+    <day which="Thursday">
+        <dayslot period="0930" course="ACIT4910">
+            <type>Lecture</type>
+            <instructor>Richard Chau</instructor>
+            <room>SW5-1840</room>
+        </dayslot>
+        <dayslot period="1030" course="ACIT4910">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1130" course="ACIT4910">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1330" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </dayslot>
+        <dayslot period="1430" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </dayslot>
+    </day>
+    <day which="Friday">
+        <dayslot period="0830" course="ACIT4660">
+            <type>Lecture</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SW9-206</room>
+        </dayslot>
+        <dayslot period="0930" course="ACIT4660">
+            <type>Lecture</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SW9-206</room>
+        </dayslot>
+        <dayslot period="1030" course="ACIT4770">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1130" course="ACIT4770">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1330" course="ACIT4660">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
+        </dayslot>
+        <dayslot period="1430" course="ACIT4660">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
         </dayslot>
     </day>
 </days>

--- a/data/periods.xml
+++ b/data/periods.xml
@@ -1,19 +1,130 @@
 <periods>
-    <period which="0930">
-        <periodslot day="tue" course="ACIT4620">
+    <period which="0830">
+        <periodslot day="Tuesday" course="ACIT4620">
             <type>Lab</type>
             <instructor>Bethany Edmunds</instructor>
             <room>SE12-306</room>
         </periodslot>
-        <periodslot day="thu" course="ACIT4910">
-            <type>Lec</type>
+        <periodslot day="Friday" course="ACIT4660">
+            <type>Lecture</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SW9-206</room>
+        </periodslot>
+    </period>
+    <period which="0930">
+        <periodslot day="Tuesday" course="ACIT4620">
+            <type>Lab</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+        <periodslot day="Thursday" course="ACIT4910">
+            <type>Lecture</type>
             <instructor>Richard Chau</instructor>
             <room>SW5-1840</room>
         </periodslot>
-        <periodslot day="fri" course="ACIT4660">
-            <type>Lec</type>
+        <periodslot day="Friday" course="ACIT4660">
+            <type>Lecture</type>
             <instructor>Steve Fabiszewski</instructor>
             <room>SW9-206</room>
+        </periodslot>
+    </period>
+    <period which="1030">
+        <periodslot day="Monday" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>Medhat Elmasry</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+        <periodslot day="Thursday" course="ACIT4910">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+        <periodslot day="Friday" course="ACIT4770">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+    </period>
+    <period which="1130">
+        <periodslot day="Monday" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>Medhat Elmasry</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+        <periodslot day="Thursday" course="ACIT4910">
+            <type>Lab</type>
+            <instructor>Richard Chau</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+        <periodslot day="Friday" course="ACIT4770">
+            <type>Tutorial</type>
+            <instructor>Trevor Lord</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+    </period>
+    <period which="1230">
+        <periodslot day="Tuesday" course="ACIT4650">
+            <type>Lecture</type>
+            <instructor>Medhat Elmasry</instructor>
+            <room>SW9-206</room>
+        </periodslot>
+        <periodslot day="Wednesday" course="ACIT4850">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </periodslot>
+    </period>
+    <period which="1330">
+        <periodslot day="Wednesday" course="ACIT4850">
+            <type>Lecture</type>
+            <instructor>James Parry</instructor>
+            <room>SW3-1750</room>
+        </periodslot>
+        <periodslot day="Thursday" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </periodslot>
+        <periodslot day="Friday" course="ACIT4660">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+    </period>
+    <period which="1430">
+        <periodslot day="Thursday" course="ACIT4850">
+            <type>Lab</type>
+            <instructor>James Parry</instructor>
+            <room>SE12-308</room>
+        </periodslot>
+        <periodslot day="Friday" course="ACIT4660">
+            <type>Lab</type>
+            <instructor>Steve Fabiszewski</instructor>
+            <room>SE12-306</room>
+        </periodslot>
+    </period>
+    <period which="1530">
+        <periodslot day="Monday" course="ACIT4910">
+            <type>Lecture</type>
+            <instructor>Richard Chau</instructor>
+            <room>SW9-206</room>
+        </periodslot>
+        <periodslot day="Tuesday" course="ACIT4620">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
+        </periodslot>
+    </period>
+    <period which="1630">
+        <periodslot day="Monday" course="ACIT4650">
+            <type>Lecture</type>
+            <instructor>Medhat Elmasry</instructor>
+            <room>SE6-205</room>
+        </periodslot>
+        <periodslot day="Tuesday" course="ACIT4620">
+            <type>Lecture</type>
+            <instructor>Bethany Edmunds</instructor>
+            <room>SW3-3615</room>
         </periodslot>
     </period>
 </periods>

--- a/data/timetable.dtd
+++ b/data/timetable.dtd
@@ -2,16 +2,16 @@
 
 <!ELEMENT timetable (days,periods,courses)>
 
-<!-- Schedule by day........................................................ -->
+<!-- Timetable by day ...................................................... -->
 <!ELEMENT days (day+)>
 
-<!ELEMENT day (day-slot+)>
+<!ELEMENT day (dayslot+)>
 <!ATTLIST day
-    which (mon|tue|wed|thu|fri) #REQUIRED
+    which (Monday|Tuesday|Wednesday|Thursday|Friday) #REQUIRED
   >
 
-<!ELEMENT day-slot (type,instructor,room)>
-<!ATTLIST day-slot
+<!ELEMENT dayslot (type,instructor,room)>
+<!ATTLIST dayslot
     period (0830|0930|1030|1130|1230|1330|1430|1530|1630) #REQUIRED
     course (ACIT4620|ACIT4650|ACIT4660|ACIT4770|ACIT4850|ACIT4910) #REQUIRED
   >
@@ -22,30 +22,30 @@
 
 <!ELEMENT room (#PCDATA)>
 
-<!-- Schedule by time....................................................... -->
+<!-- Timetable by time ..................................................... -->
 <!ELEMENT periods (period+)>
 
-<!ELEMENT period (period-slot+)>
+<!ELEMENT period (periodslot+)>
 <!ATTLIST period
     which (0830|0930|1030|1130|1230|1330|1430|1530|1630) #REQUIRED
   >
 
-<!ELEMENT period-slot (type,instructor,room)>
-<!ATTLIST period-slot
-    day (mon|tue|wed|thu|fri) #REQUIRED
+<!ELEMENT periodslot (type,instructor,room)>
+<!ATTLIST periodslot
+    day (Monday|Tuesday|Wednesday|Thursday|Friday) #REQUIRED
     course (ACIT4620|ACIT4650|ACIT4660|ACIT4770|ACIT4850|ACIT4910) #REQUIRED
   >
 
-<!-- Schedule by course..................................................... -->
+<!-- Timetable by course ................................................... -->
 <!ELEMENT courses (course+)>
 
-<!ELEMENT course (course-slot+)>
+<!ELEMENT course (courseslot+)>
 <!ATTLIST course
     which (ACIT4620|ACIT4650|ACIT4660|ACIT4770|ACIT4850|ACIT4910) #REQUIRED
   >
 
-<!ELEMENT course-slot (type,instructor,room)>
-<!ATTLIST course-slot
-    day (mon|tue|wed|thu|fri) #REQUIRED
+<!ELEMENT courseslot (type,instructor,room)>
+<!ATTLIST courseslot
+    day (Monday|Tuesday|Wednesday|Thursday|Friday) #REQUIRED
     period (0830|0930|1030|1130|1230|1330|1430|1530|1630) #REQUIRED
   >

--- a/data/timetable.xml
+++ b/data/timetable.xml
@@ -1,79 +1,393 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE timetable SYSTEM "timetable.dtd">
-    <!--[
-        <!ENTITY days SYSTEM "days.xml">
-        <!ENTITY periods SYSTEM "periods.xml">
-        <!ENTITY courses SYSTEM "courses.xml">
-    ]> -->
+<!--[
+    <!ENTITY days SYSTEM "days.xml">
+    <!ENTITY periods SYSTEM "periods.xml">
+    <!ENTITY courses SYSTEM "courses.xml">
+]> -->
 
 <timetable>
+    
+    <!-- Timetable by day .................................................. -->
     <days>
-    <day which="mon">
-        <dayslot period="1030" course="ACIT4650">
-            <type>Lab</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE12-306</room>
-        </dayslot>
-        <dayslot period="1130" course="ACIT4650">
-            <type>Lab</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE12-306</room>
-        </dayslot>
-        <dayslot period="1530" course="ACIT4910">
-            <type>Lec</type>
-            <instructor>Richard Chau</instructor>
-            <room>SW9-206</room>
-        </dayslot>
-        <dayslot period="1630" course="ACIT4650">
-            <type>Lec</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE6-205</room>
-        </dayslot>
-    </day>
+        <day which="Monday">
+            <dayslot period="1030" course="ACIT4650">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1130" course="ACIT4650">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1530" course="ACIT4910">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW9-206</room>
+            </dayslot>
+            <dayslot period="1630" course="ACIT4650">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE6-205</room>
+            </dayslot>
+        </day>
+        <day which="Tuesday">
+            <dayslot period="0830" course="ACIT4620">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="0930" course="ACIT4620">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1230" course="ACIT4650">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SW9-206</room>
+            </dayslot>
+            <dayslot period="1530" course="ACIT4620">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </dayslot>
+            <dayslot period="1630" course="ACIT4620">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </dayslot>
+        </day>
+        <day which="Wednesday">
+            <dayslot period="1230" course="ACIT4850">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </dayslot>
+            <dayslot period="1330" course="ACIT4850">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </dayslot>
+        </day>
+        <day which="Thursday">
+            <dayslot period="0930" course="ACIT4910">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW5-1840</room>
+            </dayslot>
+            <dayslot period="1030" course="ACIT4910">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1130" course="ACIT4910">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1330" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </dayslot>
+            <dayslot period="1430" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </dayslot>
+        </day>
+        <day which="Friday">
+            <dayslot period="0830" course="ACIT4660">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </dayslot>
+            <dayslot period="0930" course="ACIT4660">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </dayslot>
+            <dayslot period="1030" course="ACIT4770">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1130" course="ACIT4770">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1330" course="ACIT4660">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+            <dayslot period="1430" course="ACIT4660">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </dayslot>
+        </day>
     </days>
     
+    <!-- Timetable by period ............................................... -->
     <periods>
-    <period which="0930">
-        <periodslot day="tue" course="ACIT4620">
-            <type>Lab</type>
-            <instructor>Bethany Edmunds</instructor>
-            <room>SE12-306</room>
-        </periodslot>
-        <periodslot day="thu" course="ACIT4910">
-            <type>Lec</type>
-            <instructor>Richard Chau</instructor>
-            <room>SW5-1840</room>
-        </periodslot>
-        <periodslot day="fri" course="ACIT4660">
-            <type>Lec</type>
-            <instructor>Steve Fabiszewski</instructor>
-            <room>SW9-206</room>
-        </periodslot>
-    </period>
+        <period which="0830">
+            <periodslot day="Tuesday" course="ACIT4620">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4660">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </periodslot>
+        </period>
+        <period which="0930">
+            <periodslot day="Tuesday" course="ACIT4620">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Thursday" course="ACIT4910">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW5-1840</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4660">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </periodslot>
+        </period>
+        <period which="1030">
+            <periodslot day="Monday" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Thursday" course="ACIT4910">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4770">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+        </period>
+        <period which="1130">
+            <periodslot day="Monday" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Thursday" course="ACIT4910">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4770">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+        </period>
+        <period which="1230">
+            <periodslot day="Tuesday" course="ACIT4650">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SW9-206</room>
+            </periodslot>
+            <periodslot day="Wednesday" course="ACIT4850">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </periodslot>
+        </period>
+        <period which="1330">
+            <periodslot day="Wednesday" course="ACIT4850">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </periodslot>
+            <periodslot day="Thursday" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4660">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+        </period>
+        <period which="1430">
+            <periodslot day="Thursday" course="ACIT4850">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </periodslot>
+            <periodslot day="Friday" course="ACIT4660">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </periodslot>
+        </period>
+        <period which="1530">
+            <periodslot day="Monday" course="ACIT4910">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW9-206</room>
+            </periodslot>
+            <periodslot day="Tuesday" course="ACIT4620">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </periodslot>
+        </period>
+        <period which="1630">
+            <periodslot day="Monday" course="ACIT4650">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE6-205</room>
+            </periodslot>
+            <periodslot day="Tuesday" course="ACIT4620">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </periodslot>
+        </period>
     </periods>
     
+    <!-- Timetable by course ............................................... -->
     <courses>
-    <course which="ACIT4650">
-        <courseslot day="mon" period="1030">
-            <type>Lab</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE12-306</room>
-        </courseslot>
-        <courseslot day="mon" period="1130">
-            <type>Lab</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE12-306</room>
-        </courseslot>
-        <courseslot day="mon" period="1630">
-            <type>Lec</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SE6-205</room>
-        </courseslot>
-        <courseslot day="tue" period="1230">
-            <type>Lec</type>
-            <instructor>Medhat Elmasry</instructor>
-            <room>SW9-206</room>
-        </courseslot>
-    </course>
+        <course which="ACIT4620">
+            <courseslot day="Tuesday" period="0830">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Tuesday" period="0930">
+                <type>Lab</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Tuesday" period="1530">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </courseslot>
+            <courseslot day="Tuesday" period="1630">
+                <type>Lecture</type>
+                <instructor>Bethany Edmunds</instructor>
+                <room>SW3-3615</room>
+            </courseslot>
+        </course>
+        <course which="ACIT4650">
+            <courseslot day="Monday" period="1030">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Monday" period="1130">
+                <type>Lab</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Monday" period="1630">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SE6-205</room>
+            </courseslot>
+            <courseslot day="Tuesday" period="1230">
+                <type>Lecture</type>
+                <instructor>Medhat Elmasry</instructor>
+                <room>SW9-206</room>
+            </courseslot>
+        </course>
+        <course which="ACIT4660">
+            <courseslot day="Friday" period="0830">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </courseslot>
+            <courseslot day="Friday" period="0930">
+                <type>Lecture</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SW9-206</room>
+            </courseslot>
+            <courseslot day="Friday" period="1330">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Friday" period="1430">
+                <type>Lab</type>
+                <instructor>Steve Fabiszewski</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+        </course>
+        <course which="ACIT4770">
+            <courseslot day="Friday" period="1030">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Friday" period="1130">
+                <type>Tutorial</type>
+                <instructor>Trevor Lord</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+        </course>
+        <course which="ACIT4850">
+            <courseslot day="Wednesday" period="1230">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </courseslot>
+            <courseslot day="Wednesday" period="1330">
+                <type>Lecture</type>
+                <instructor>James Parry</instructor>
+                <room>SW3-1750</room>
+            </courseslot>
+            <courseslot day="Thursday" period="1330">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </courseslot>
+            <courseslot day="Thursday" period="1430">
+                <type>Lab</type>
+                <instructor>James Parry</instructor>
+                <room>SE12-308</room>
+            </courseslot>
+        </course>
+        <course which="ACIT4910">
+            <courseslot day="Monday" period="1530">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW9-206</room>
+            </courseslot>
+            <courseslot day="Thursday" period="0930">
+                <type>Lecture</type>
+                <instructor>Richard Chau</instructor>
+                <room>SW5-1840</room>
+            </courseslot>
+            <courseslot day="Thursday" period="1030">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+            <courseslot day="Thursday" period="1130">
+                <type>Lab</type>
+                <instructor>Richard Chau</instructor>
+                <room>SE12-306</room>
+            </courseslot>
+        </course>
     </courses>
+
 </timetable>


### PR DESCRIPTION
- Added complete ACIT 4A timetable data to timetable.xml, days.xml, periods.xml, and courses.xml.
- Updated timetable data to include full day names and the full word "Lecture" as opposed to abbreviations.
- Updated timetable.dtd to reflect the data changes in timetable.xml.
- Updated Timetable.php to reflect the data changes in timetable.xml.
Signed-off-by:Erick <efernandezcraft@gmail.com>